### PR TITLE
Add icons to services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,67 +96,89 @@
         <div class="services-grid">
             <!-- 1. Wall Breaking -->
             <div class="service-card">
-                <div class="icon service-wall"></div>
+                <div class="icon">
+                    <img src="icons/wall.svg" alt="Duvar kırma ikonu">
+                </div>
                 <h3>Duvar Kırma</h3>
                 <p>Bina, ev veya ofislerde profesyonel duvar yıkımı ve sökümü.</p>
             </div>
             <!-- 2. Debris Removal -->
             <div class="service-card">
-                <div class="icon service-debris"></div>
+                <div class="icon">
+                    <img src="icons/debris.svg" alt="Moloz atımı ikonu">
+                </div>
                 <h3>Moloz Atımı</h3>
                 <p>Çuvallı &amp; çuvalsız moloz atım hizmeti.</p>
             </div>
             <!-- 3. Bathroom Demolition -->
             <div class="service-card">
-                <div class="icon service-bathroom"></div>
+                <div class="icon">
+                    <img src="icons/bath.svg" alt="Banyo kırma ikonu">
+                </div>
                 <h3>Banyo Kırma</h3>
                 <p>Banyo tadilatları için kırma ve söküm işleri.</p>
             </div>
             <!-- 4. Kitchen Demolition -->
             <div class="service-card">
-                <div class="icon service-kitchen"></div>
+                <div class="icon">
+                    <img src="icons/kitchen.svg" alt="Mutfak kırma ikonu">
+                </div>
                 <h3>Mutfak Kırma</h3>
                 <p>Mutfak yenilemeleri için hızlı söküm.</p>
             </div>
             <!-- 5. Screed Removal -->
             <div class="service-card">
-                <div class="icon service-screed"></div>
+                <div class="icon">
+                    <img src="icons/screed.svg" alt="Şap kırma ikonu">
+                </div>
                 <h3>Şap Kırma</h3>
                 <p>Zemin şap kırımı ve temizliği.</p>
             </div>
             <!-- 6. Roof Dismantling -->
             <div class="service-card">
-                <div class="icon service-roof"></div>
+                <div class="icon">
+                    <img src="icons/roof.svg" alt="Çatı sökme ikonu">
+                </div>
                 <h3>Çatı Sökme</h3>
                 <p>Çatı, sundurma ve teras söküm işlemleri.</p>
             </div>
             <!-- 7. Pool Tile Removal -->
             <div class="service-card">
-                <div class="icon service-pool"></div>
+                <div class="icon">
+                    <img src="icons/pool.svg" alt="Havuz fayans kırma ikonu">
+                </div>
                 <h3>Havuz Fayans Kırma</h3>
                 <p>Havuzlarda fayans, mozaik ve seramik kırımı.</p>
             </div>
             <!-- 8. Building Demolition -->
             <div class="service-card">
-                <div class="icon service-building"></div>
+                <div class="icon">
+                    <img src="icons/building.svg" alt="Bina yıkım ikonu">
+                </div>
                 <h3>Bina Yıkım</h3>
                 <p>Tam kapsamlı bina yıkım hizmetleri.</p>
             </div>
             <!-- 9. Concrete Cutting -->
             <div class="service-card">
-                <div class="icon service-concrete"></div>
+                <div class="icon">
+                    <img src="icons/concrete.svg" alt="Beton kesme ikonu">
+                </div>
                 <h3>Beton Kesme</h3>
                 <p>Endüstriyel ve konut tipi beton kesme.</p>
             </div>
             <!-- 10. Core Drilling Services -->
             <div class="service-card">
-                <div class="icon service-core"></div>
+                <div class="icon">
+                    <img src="icons/core.svg" alt="Karot hizmetleri ikonu">
+                </div>
                 <h3>Karot Hizmetleri</h3>
                 <p>Profesyonel karot ile delik açma.</p>
             </div>
             <!-- 11. Mini-Excavator Services -->
             <div class="service-card">
-                <div class="icon service-excavator"></div>
+                <div class="icon">
+                    <img src="icons/excavator.svg" alt="Mini kepçe hizmetleri ikonu">
+                </div>
                 <h3>Mini Kepçe Hizmetleri</h3>
                 <p>Küçük alanlar için mini ekskavatör hizmeti.</p>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -139,7 +139,9 @@ nav {
 .service-card .icon {
   margin-bottom: 1.1rem; width: 56px; height: 56px;
   background: var(--accent); border-radius: 50%; display: flex; align-items: center; justify-content: center;
-  /* Placeholder for icon SVGs below */
+}
+.service-card .icon img {
+  width: 54%; height: 54%; object-fit: contain;
 }
 .service-card h3 {
   font-size: 1.23rem; margin: .2rem 0 .8rem 0; font-weight: 700; color: var(--text);
@@ -148,18 +150,6 @@ nav {
   color: #444b; font-size: 1rem; margin: 0;
 }
 
-/* Example SVG icons for demonstration. You should replace the background with inline SVGs in HTML for best SEO and accessibility */
-.service-wall      { background: var(--accent) url('icons/wall.svg')   center/54% no-repeat; }
-.service-debris    { background: var(--accent) url('icons/debris.svg') center/54% no-repeat; }
-.service-bathroom  { background: var(--accent) url('icons/bath.svg')   center/54% no-repeat; }
-.service-kitchen   { background: var(--accent) url('icons/kitchen.svg')center/54% no-repeat; }
-.service-screed    { background: var(--accent) url('icons/screed.svg') center/54% no-repeat; }
-.service-roof      { background: var(--accent) url('icons/roof.svg')   center/54% no-repeat; }
-.service-pool      { background: var(--accent) url('icons/pool.svg')   center/54% no-repeat; }
-.service-building  { background: var(--accent) url('icons/building.svg')center/54% no-repeat; }
-.service-concrete  { background: var(--accent) url('icons/concrete.svg')center/54% no-repeat; }
-.service-core      { background: var(--accent) url('icons/core.svg')   center/54% no-repeat; }
-.service-excavator { background: var(--accent) url('icons/excavator.svg')center/54% no-repeat; }
 
 /* Projects & Gallery */
 .projects {


### PR DESCRIPTION
## Summary
- Embed dedicated SVG icons for each service in the Hizmetlerimiz grid
- Simplify service card styling and drop service-specific background classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689980be956c832c93b91ba5170c7a20